### PR TITLE
Update README.md: changing Body reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This course is for aspiring developers who want to learn how to work with data i
 1. What is `fetch()`?
    - [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
    - Promises, async and await
-   - [Body - Web APIs](https://developer.mozilla.org/en-US/docs/Web/API/Body)
+   - [Response - Web APIs](https://developer.mozilla.org/en-US/docs/Web/API/Response)
    - `<img>` DOM element
 
 #### 1b: Tabular Data


### PR DESCRIPTION
"Body - Web APIs" refers to a non-existent page. 

The current link is: https://developer.mozilla.org/en-US/docs/Web/API/Body , which is not found in Mozilla website.

So, I'm suggesting to change it to the "Response" reference that contains "Response.body" reference and relevant information for viewers, also it fits with what is said in the video(https://youtu.be/tc8DU14qX6I&t=210). Viewers can learn about "Response" and "Response.body" on the new link.